### PR TITLE
Fix deprecation warning

### DIFF
--- a/app/validators/date_format_validator.rb
+++ b/app/validators/date_format_validator.rb
@@ -13,7 +13,7 @@ class DateFormatValidator < ActiveModel::EachValidator
     begin
       Date.parse(value)
     rescue
-      record.errors.add(attr_name, :date_format, options)
+      record.errors.add(attr_name, :date_format, **options)
     end
   end
 end

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -18,6 +18,6 @@ class EmailFormatValidator < ActiveModel::EachValidator
 
   def validate_each(record, attr_name, value)
     return if value.blank?
-    record.errors.add(attr_name, :email_format, options) unless value =~ EMAIL_REGEX
+    record.errors.add(attr_name, :email_format, **options) unless value =~ EMAIL_REGEX
   end
 end

--- a/app/validators/money_format_validator.rb
+++ b/app/validators/money_format_validator.rb
@@ -37,7 +37,7 @@ class MoneyFormatValidator < ActiveModel::EachValidator
     # Regex seems a bit odd to use here (vs converting to BigDeciaml) but we need
     # to check for values that BigDecimal can't represent (e.g., "badvalue") so
     # for now this works.
-    record.errors.add(attr_name, :money_format, options) unless value =~ MONEY_REGEX
+    record.errors.add(attr_name, :money_format, **options) unless value =~ MONEY_REGEX
 
     # Check if value has cents but shouldn't
     if options[:exclude_cents] && value_has_cents?(value)

--- a/app/validators/phone_number_format_validator.rb
+++ b/app/validators/phone_number_format_validator.rb
@@ -15,6 +15,6 @@ class PhoneNumberFormatValidator < ActiveModel::EachValidator
 
   def validate_each(record, attr_name, value)
     return if value.blank?
-    record.errors.add(attr_name, :phone_number_format, options) unless value =~ PHONE_NUMBER_REGEX
+    record.errors.add(attr_name, :phone_number_format, **options) unless value =~ PHONE_NUMBER_REGEX
   end
 end

--- a/app/validators/slug_format_validator.rb
+++ b/app/validators/slug_format_validator.rb
@@ -12,6 +12,6 @@ class SlugFormatValidator < ActiveModel::EachValidator
 
   def validate_each(record, attr_name, value)
     return if value.blank?
-    record.errors.add(attr_name, :slug_format, options) unless value =~ SLUG_REGEX
+    record.errors.add(attr_name, :slug_format, **options) unless value =~ SLUG_REGEX
   end
 end

--- a/app/validators/url_format_validator.rb
+++ b/app/validators/url_format_validator.rb
@@ -14,6 +14,6 @@ class UrlFormatValidator < ActiveModel::EachValidator
     rescue URI::InvalidURIError
       false
     end
-    record.errors.add(attr_name, :url_format, options) unless valid
+    record.errors.add(attr_name, :url_format, **options) unless valid
   end
  end

--- a/lib/common_validators/version.rb
+++ b/lib/common_validators/version.rb
@@ -1,3 +1,3 @@
 module CommonValidators
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
**Description**

Newer rails projects which use `common_validators` may complain with a deprecation warning:

```
Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

This PR updates option params with splat (**) to ensure future compatibility.